### PR TITLE
ExecutionNode

### DIFF
--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -29,11 +29,22 @@ def analyze(tree: ast.Module) -> dict:
     dependency_map = dict()
 
     for function in functions:
-        args = set()
+        args = []
         for arg in function.args.args:
-            annotation = arg.annotation.id if arg.annotation is not None else None
-            args.add((arg.arg, annotation))
-        returns = function.returns.id if function.returns is not None else None
+            annotation = None
+            if arg.annotation is not None:
+                if isinstance(arg.annotation, ast.Str):
+                    annotation = arg.annotation.s
+                else:
+                    annotation = arg.annotation.id
+            args.append((arg.arg, annotation))
+
+        returns = None
+        if function.returns is not None:
+            if isinstance(function.returns, ast.Str):
+                returns = function.returns.s
+            else:
+                returns = function.returns.id
         dependency_map[function.name] = Dependency(args, returns, function)
 
     return dependency_map

--- a/src/execution_graph.py
+++ b/src/execution_graph.py
@@ -1,0 +1,35 @@
+from .analyzer import Dependency
+
+
+class ExecutionNode:
+    def __init__(self, name: str, byte_code, dep_data: Dependency):
+        self.name = name
+        self.code = byte_code
+        self.subscribers = []
+        self.param_vals = {}  # map type -> val as they come in
+        self.dep_data = dep_data
+        self.executed = False
+        self.result = None
+
+    def is_independent(self):
+        return len(self.dep_data.dependencies) == 0
+
+    def add_subscriber(self, node):
+        self.subscribers.append(node)
+
+    def can_execute(self):
+        for (_, argtype) in self.dep_data.dependencies:
+            if argtype not in self.param_vals:
+                return False
+        return True
+
+    def execute(self):
+        assert self.can_execute()
+
+        if self.executed:
+            return self.result
+
+        param_sequence = [self.param_vals[argtype] for (_, argtype) in self.dep_data.dependencies]
+        self.result = self.code(*param_sequence)
+        self.executed = True
+        return self.result

--- a/tests/analyzer_test.py
+++ b/tests/analyzer_test.py
@@ -5,15 +5,17 @@ from src.analyzer import *
 
 class AnalyzerTest(unittest.TestCase):
 
-    one_function = '''def f(x: param) -> result: return x'''
+    function_str = '''def f(x: 'param') -> 'result': return x'''
+    function_named = '''def f(x: param) -> result: return x'''
 
     def test_analyze(self):
-        tree = parse(self.one_function)
-        dependencies = analyze(tree)
-        self.assertIn('f', dependencies)
-        dependency_data = dependencies['f']
-        self.assertIn(('x', 'param'), dependency_data.dependencies)
-        self.assertEqual('result', dependency_data.returns)
+        for function in [self.function_str, self.function_named]:
+            tree = parse(function)
+            dependencies = analyze(tree)
+            self.assertIn('f', dependencies)
+            dependency_data = dependencies['f']
+            self.assertIn(('x', 'param'), dependency_data.dependencies)
+            self.assertEqual('result', dependency_data.returns)
 
 
 if __name__ == '__main__':

--- a/tests/execution_graph_test.py
+++ b/tests/execution_graph_test.py
@@ -1,0 +1,36 @@
+import unittest
+from src.execution_graph import *
+
+
+def f(x: 'param1', y: 'param2') -> 'result':
+    return [x, y]
+
+
+class ExecutionNodeTest(unittest.TestCase):
+    param_seq = [('x', 'param1'), ('y', 'param2')]
+    returns = 'result'
+    name = 'f'
+    dep_data = Dependency(param_seq, returns, None)
+
+    def test_init(self):
+        node = ExecutionNode(self.name, f, self.dep_data)
+        self.assertFalse(node.is_independent())
+        self.assertFalse(node.can_execute())
+        self.assertFalse(node.executed)
+        self.assertIsNone(node.result)
+
+    def test_execute(self):
+        node = ExecutionNode(self.name, f, self.dep_data)
+        node.param_vals = {
+            'param1': 1,
+            'param2': 2
+        }
+        self.assertTrue(node.can_execute())
+        result = node.execute()
+        self.assertEqual(result, [1, 2])
+        self.assertTrue(node.executed)
+        self.assertEqual(node.result, [1, 2])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/execution_graph_test.py
+++ b/tests/execution_graph_test.py
@@ -31,6 +31,12 @@ class ExecutionNodeTest(unittest.TestCase):
         self.assertTrue(node.executed)
         self.assertEqual(node.result, [1, 2])
 
+    def test_cannot_execute(self):
+        node = ExecutionNode(self.name, f, self.dep_data)
+        node.param_vals = {'param1': 1}
+        self.assertFalse(node.can_execute())
+        self.assertRaises(AssertionError, node.execute)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
ExecutionNode is used to wrap function calls.

- A function can be called (executed) if and only if all of its parameters (dependencies) have been resolved. 
- An ExecutionNode has subscribers, which are other nodes that depend on the output of itself. 
- Every node is executed only once per request
- Added unit tests for ExecutionNode

Added support for 'string' annotations in analyzer. Example:
```python

def f(x: NormalAnnotation) -> result:
  return x

def g(x: 'StringAnnotation') -> 'result':
  return x
```