### PR TITLE
Single threaded execution

### DIFF
--- a/src/execution_graph.py
+++ b/src/execution_graph.py
@@ -1,3 +1,4 @@
+import ast
 from .analyzer import Dependency
 
 
@@ -14,7 +15,7 @@ class ExecutionNode:
     def is_independent(self):
         return len(self.dep_data.dependencies) == 0
 
-    def add_subscriber(self, node):
+    def add_subscriber(self, node: 'ExecutionNode'):
         self.subscribers.append(node)
 
     def can_execute(self):
@@ -23,13 +24,62 @@ class ExecutionNode:
                 return False
         return True
 
-    def execute(self):
+    def produces(self):
+        return self.dep_data.returns
+
+    def execute(self, results_map: dict):
         assert self.can_execute()
 
         if self.executed:
             return self.result
-
         param_sequence = [self.param_vals[argtype] for (_, argtype) in self.dep_data.dependencies]
         self.result = self.code(*param_sequence)
+        results_map[self.name] = self.result
         self.executed = True
+
+        for subscriber in self.subscribers:
+            subscriber.param_vals[self.produces()] = self.result
+
+            if subscriber.can_execute():
+                subscriber.execute(results_map)
         return self.result
+
+
+class ExecutionGraph:
+    def __init__(self, tree: ast.Module, dep_data: dict):
+        self.codeMap = {}
+        bytecode = compile(tree, filename='<ast>', mode='exec')
+        namespace = {}
+        exec(bytecode, namespace)
+        independent = set()
+        dependent = set()
+        for function_name, dependency in dep_data.items():
+            function_code = namespace[function_name]
+            self.codeMap[function_name] = function_code
+            node = ExecutionNode(function_name, function_code, dependency)
+            if node.is_independent():
+                independent.add(node)
+            else:
+                dependent.add(node)
+
+        # resolve all dependencies
+        for node in dependent:
+            depends_on = set([argType for (_, argType) in node.dep_data.dependencies])
+            for indep_node in independent:
+                if indep_node.produces() in depends_on:
+                    indep_node.add_subscriber(node)
+            for dep_node in dependent:
+                if node is not dep_node and dep_node.produces() in depends_on:
+                    dep_node.add_subscriber(node)
+
+            # TODO check if there is dependency not resolved
+
+        self.root = independent
+        self.branches = dependent
+
+    def execute(self) -> dict:
+        results_map = {}
+        for node in self.root:
+            node.execute(results_map)
+
+        return results_map

--- a/tests/analyzer_test.py
+++ b/tests/analyzer_test.py
@@ -1,5 +1,4 @@
 import unittest
-import ast
 from src.analyzer import *
 
 

--- a/tests/execution_graph_test.py
+++ b/tests/execution_graph_test.py
@@ -1,41 +1,68 @@
 import unittest
 from src.execution_graph import *
+from src.analyzer import *
 
 
-def f(x: 'param1', y: 'param2') -> 'result':
+def two_params(x: 'param1', y: 'param2') -> 'result':
     return [x, y]
 
 
-class ExecutionNodeTest(unittest.TestCase):
+class ExecutionGraphTest(unittest.TestCase):
     param_seq = [('x', 'param1'), ('y', 'param2')]
     returns = 'result'
-    name = 'f'
-    dep_data = Dependency(param_seq, returns, None)
+    name = 'two_params'
+    node_dep_data = Dependency(param_seq, returns, None)
 
-    def test_init(self):
-        node = ExecutionNode(self.name, f, self.dep_data)
+    def setUp(self) -> None:
+        with open('test_src.py', 'r') as src:
+            self.tree = parse(src.read())
+
+        self.graph_dep_data = analyze(self.tree)
+
+    def test_node_init(self):
+        node = ExecutionNode(self.name, two_params, self.node_dep_data)
         self.assertFalse(node.is_independent())
         self.assertFalse(node.can_execute())
         self.assertFalse(node.executed)
         self.assertIsNone(node.result)
 
-    def test_execute(self):
-        node = ExecutionNode(self.name, f, self.dep_data)
+    def test_node_execute(self):
+        node = ExecutionNode(self.name, two_params, self.node_dep_data)
         node.param_vals = {
             'param1': 1,
             'param2': 2
         }
+        results_map = {}
         self.assertTrue(node.can_execute())
-        result = node.execute()
+        result = node.execute(results_map)
         self.assertEqual(result, [1, 2])
         self.assertTrue(node.executed)
         self.assertEqual(node.result, [1, 2])
+        self.assertEqual(results_map, {'two_params': [1, 2]})
 
-    def test_cannot_execute(self):
-        node = ExecutionNode(self.name, f, self.dep_data)
+    def test_node_cannot_execute(self):
+        node = ExecutionNode(self.name, two_params, self.node_dep_data)
         node.param_vals = {'param1': 1}
         self.assertFalse(node.can_execute())
-        self.assertRaises(AssertionError, node.execute)
+        self.assertRaises(AssertionError, node.execute, {})
+
+    def test_graph_init(self):
+        graph = ExecutionGraph(self.tree, self.graph_dep_data)
+        self.assertEqual(len(graph.root), 2)
+        self.assertEqual(len(graph.branches), 4)
+
+    def test_graph_execute_single_threaded(self):
+        graph = ExecutionGraph(self.tree, self.graph_dep_data)
+        results = graph.execute()
+        expected = {
+            'f': 123,
+            'g': 345,
+            'h': [123, 345],
+            'a': [123, 345, 567],
+            'b': [123, 345, 789],
+            'c': [123, 345, 567, 123, 345, 789]
+        }
+        self.assertDictEqual(results, expected)
 
 
 if __name__ == '__main__':

--- a/tests/test_src.py
+++ b/tests/test_src.py
@@ -1,0 +1,23 @@
+
+def f() -> 'result1':
+    return 123
+
+
+def g() -> 'result2':
+    return 345
+
+
+def h(x: 'result1', y: 'result2') -> 'result3':
+    return [x, y]
+
+
+def a(x: 'result3') -> 'result4':
+    return x + [567]
+
+
+def b(y: 'result3') -> 'result5':
+    return y + [789]
+
+
+def c(x: 'result4', y: 'result5'):
+    return x + y


### PR DESCRIPTION
Added ExecutionGraph class which builds the graph and provides ability to execute all nodes.

- currently dependent nodes are correctly executed after their dependencies, however independent nodes are executed one at a time.
- in other words, only single threaded for now
- added unit tests and example source file


