### PR TITLE
Multi threaded execution

### DIFF
--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -25,7 +25,7 @@ def analyze(tree: ast.Module) -> dict:
     :param tree: an AST Module node
     :return: a dictionary with function names as key
     """
-    functions = tree.body
+    functions = [node for node in tree.body if isinstance(node, ast.FunctionDef)]
     dependency_map = dict()
 
     for function in functions:

--- a/tests/execution_graph_test.py
+++ b/tests/execution_graph_test.py
@@ -1,6 +1,7 @@
 import unittest
 from src.execution_graph import *
 from src.analyzer import *
+from concurrent.futures import ThreadPoolExecutor
 
 
 def two_params(x: 'param1', y: 'param2') -> 'result':
@@ -34,8 +35,8 @@ class ExecutionGraphTest(unittest.TestCase):
         }
         results_map = {}
         self.assertTrue(node.can_execute())
-        result = node.execute(results_map)
-        self.assertEqual(result, [1, 2])
+        with ThreadPoolExecutor() as executor:
+            node.execute(results_map, executor)
         self.assertTrue(node.executed)
         self.assertEqual(node.result, [1, 2])
         self.assertEqual(results_map, {'two_params': [1, 2]})
@@ -44,7 +45,7 @@ class ExecutionGraphTest(unittest.TestCase):
         node = ExecutionNode(self.name, two_params, self.node_dep_data)
         node.param_vals = {'param1': 1}
         self.assertFalse(node.can_execute())
-        self.assertRaises(AssertionError, node.execute, {})
+        self.assertRaises(AssertionError, node.execute, {}, None)
 
     def test_graph_init(self):
         graph = ExecutionGraph(self.tree, self.graph_dep_data)

--- a/tests/execution_graph_test.py
+++ b/tests/execution_graph_test.py
@@ -54,7 +54,22 @@ class ExecutionGraphTest(unittest.TestCase):
 
     def test_graph_execute_single_threaded(self):
         graph = ExecutionGraph(self.tree, self.graph_dep_data)
-        results = graph.execute()
+        results = graph.execute(max_workers=1)
+        # takes approx 6 seconds
+        expected = {
+            'f': 123,
+            'g': 345,
+            'h': [123, 345],
+            'a': [123, 345, 567],
+            'b': [123, 345, 789],
+            'c': [123, 345, 567, 123, 345, 789]
+        }
+        self.assertDictEqual(results, expected)
+
+    def test_graph_execute_multi_threaded(self):
+        graph = ExecutionGraph(self.tree, self.graph_dep_data)
+        results = graph.execute(max_workers=2)
+        # takes approx 4 seconds
         expected = {
             'f': 123,
             'g': 345,

--- a/tests/test_src.py
+++ b/tests/test_src.py
@@ -1,23 +1,31 @@
+import time
+
 
 def f() -> 'result1':
+    time.sleep(1)
     return 123
 
 
 def g() -> 'result2':
+    time.sleep(1)
     return 345
 
 
 def h(x: 'result1', y: 'result2') -> 'result3':
+    time.sleep(1)
     return [x, y]
 
 
 def a(x: 'result3') -> 'result4':
+    time.sleep(1)
     return x + [567]
 
 
 def b(y: 'result3') -> 'result5':
+    time.sleep(1)
     return y + [789]
 
 
 def c(x: 'result4', y: 'result5'):
+    time.sleep(1)
     return x + y


### PR DESCRIPTION
Execution of nodes is now done concurrently whenever possible

- use `concurrent.futures` to execute independent nodes in parallel
- have each task return a list of futures to represent the child tasks which were spawned from the parent task
- use the list of futures to recursively determine when all tasks have been completed
- user can specify num of max threads in executor pool
- added more tests/documentation
- example src code uses sleep to demonstrate effect of parallel execution
- fix bug where every node in AST was assumed to be FunctionDef, this is not necessarily the case. It can be import, or other statement.