### PR TITLE
Allow initial parameters to be passed to root nodes

### DIFF
--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -32,13 +32,12 @@ def analyze(tree: ast.Module) -> Dict[str, Dependency]:
     for function in functions:
         args = []
         for arg in function.args.args:
-            annotation = None
             if arg.annotation is not None:
                 if isinstance(arg.annotation, ast.Str):
                     annotation = arg.annotation.s
                 else:
                     annotation = arg.annotation.id
-            args.append((arg.arg, annotation))
+                args.append((arg.arg, annotation))
 
         returns = None
         if function.returns is not None:

--- a/tests/analyzer_test.py
+++ b/tests/analyzer_test.py
@@ -5,8 +5,9 @@ from src.analyzer import *
 class AnalyzerTest(unittest.TestCase):
     function_str = '''def f(x: 'param') -> 'result': return x'''
     function_named = '''def f(x: param) -> result: return x'''
+    function_no_annotation = '''def f(x) -> result: return x'''
 
-    def test_analyze(self):
+    def test_analyze_annotations(self):
         for function in [self.function_str, self.function_named]:
             tree = parse(function)
             dependencies = analyze(tree)
@@ -14,6 +15,11 @@ class AnalyzerTest(unittest.TestCase):
             dependency_data = dependencies['f']
             self.assertIn(('x', 'param'), dependency_data.dependencies)
             self.assertEqual('result', dependency_data.returns)
+
+    def test_analyze_no_annotations(self):
+        dependencies = analyze(parse(self.function_no_annotation))
+        self.assertIn('f', dependencies)
+        self.assertListEqual(dependencies['f'].dependencies, [])
 
 
 if __name__ == '__main__':

--- a/tests/execution_graph_test.py
+++ b/tests/execution_graph_test.py
@@ -54,7 +54,11 @@ class ExecutionGraphTest(unittest.TestCase):
 
     def test_graph_execute_single_threaded(self):
         graph = ExecutionGraph(self.tree, self.graph_dep_data)
-        results = graph.execute(max_workers=1)
+        start_params = {
+            'f': [123, 'abc'],
+            'g': [345]
+        }
+        results = graph.execute(start_params=start_params, max_workers=1)
         # takes approx 6 seconds
         expected = {
             'f': 123,
@@ -68,7 +72,11 @@ class ExecutionGraphTest(unittest.TestCase):
 
     def test_graph_execute_multi_threaded(self):
         graph = ExecutionGraph(self.tree, self.graph_dep_data)
-        results = graph.execute(max_workers=2)
+        start_params = {
+            'f': [123, 'abc'],
+            'g': [345]
+        }
+        results = graph.execute(start_params, max_workers=2)
         # takes approx 4 seconds
         expected = {
             'f': 123,

--- a/tests/test_src.py
+++ b/tests/test_src.py
@@ -1,12 +1,13 @@
 import time
 
 
-def f() -> 'result1':
+def f(x, y) -> 'result1':
+    print('f: ' + str(y))
     time.sleep(1)
     return 123
 
 
-def g() -> 'result2':
+def g(y) -> 'result2':
     time.sleep(1)
     return 345
 


### PR DESCRIPTION
Can now give root functions some initial starting value (ie user id)
Example:

```python
def getOrdersForUser(id):
  pass
```

can be called with

```python
user_id = {
  'getOrdersForUser': [1234]
}
graph.execute(userid, max_workers=4)
```
A dictionary is used since there may be several root functions, so this way we can forward all parameters at once.